### PR TITLE
fix(admincdn): 镜像不可用时回退，不再把站点资源一起带死

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to `WP-China-Yes` will be documented in this file.
 
+## 未发布
+
+### 修复
+- **加速镜像不可用时不再把站点资源一起带死**：`admincdn` 各镜像端点新增健康检测
+  （`Service/MirrorHealth.php`），端点不可用时跳过替换、保留原始公共 CDN 链接，
+  端点恢复后自动重新启用，并在后台提示当前回退状态。
+  此前替换是无条件的字符串/正则替换，镜像故障会导致站点前端 JS/CSS/字体大面积 404 ——
+  把可用的公共 CDN 换成失效镜像，比不加速更糟。
+- **emoji 替换的守卫前置**：此前先 `remove_action` 摘掉 WP 自带 emoji 处理再指向镜像，
+  镜像失效时等于既拿掉核心行为又没有替代品，现改为镜像不可用则完全不接管。
+- **后台加速在镜像不可用时不再无谓关闭脚本合并**（`$concatenate_scripts`），此前有损无益。
+- **修复两处无开关控制的硬编码 CDN 依赖**：`framework/fields/map`（leaflet）与
+  `framework/fields/code_editor`（codemirror）此前硬编码 `jsd.admincdn.com`，
+  不受任何加速开关控制，镜像故障会直接让插件自己的设置界面失效。
+  现经 `field_cdn_base()` 取址，不可用时回退到 `cdn.jsdmirror.com`
+  （国内可达；`cdn.jsdelivr.net` 自 2021-12 ICP 吊销后国内基本不可用）。
+
 ## v3.9 - 2026-02-15
 
 ### 新增

--- a/Service/Acceleration.php
+++ b/Service/Acceleration.php
@@ -298,6 +298,11 @@ class Acceleration {
             !stristr($GLOBALS['wp_version'], 'beta') &&
             !stristr($GLOBALS['wp_version'], 'RC')) {
             
+            // 镜像不可用时直接返回：此时关闭脚本合并只会变慢而没有任何收益
+            if (!$this->mirror_usable('wpstatic.admincdn.com')) {
+                return;
+            }
+
             global $concatenate_scripts;
             $concatenate_scripts = false;
 
@@ -311,7 +316,8 @@ class Acceleration {
      * 准备前台替换规则
      */
     private function prepare_frontend_replacements() {
-        if (in_array('frontend', (array) $this->settings['admincdn_files'])) {
+        if (in_array('frontend', (array) $this->settings['admincdn_files'])
+            && $this->mirror_usable('public.admincdn.com')) {
             $pattern = '#(?<=[(\"\'])(?:' . quotemeta(home_url()) . ')?/(?:((?:wp-content|wp-includes)[^\"\')]+\.(css|js)[^\"\')]+))(?=[\"\')])#';
             $this->regex_patterns[$pattern] = 'https://public.admincdn.com/$0';
         }
@@ -330,7 +336,8 @@ class Acceleration {
         ];
 
         foreach ($public_libraries as $key => $replacement) {
-            if (in_array($key, (array) $this->settings['admincdn_public'])) {
+            if (in_array($key, (array) $this->settings['admincdn_public'])
+                && $this->mirror_usable($replacement[1])) {
                 $this->replacements[$replacement[0]] = $replacement[1];
             }
         }
@@ -349,10 +356,24 @@ class Acceleration {
         ];
 
         foreach ($dev_libraries as $key => $replacement) {
-            if (in_array($key, (array) $this->settings['admincdn_dev'])) {
+            if (in_array($key, (array) $this->settings['admincdn_dev'])
+                && $this->mirror_usable($replacement[1])) {
                 $this->replacements[$replacement[0]] = $replacement[1];
             }
         }
+    }
+
+    /**
+     * 镜像端点当前是否可用 —— 不可用就不替换，保留原始公共 CDN 链接。
+     *
+     * 加速服务挂掉时不应该把站点资源一起带死：把可用的公共 CDN 换成
+     * 已失效的镜像，比不加速更糟。详见 Service/MirrorHealth.php。
+     *
+     * @param string $target 替换目标（可能带路径）
+     * @return bool
+     */
+    private function mirror_usable($target) {
+        return MirrorHealth::is_healthy(MirrorHealth::host_of($target));
     }
 
     /**
@@ -372,6 +393,12 @@ class Acceleration {
      * 准备Emoji替换规则
      */
     private function prepare_emoji_replacements() {
+        // 守卫必须在 remove_action 之前：镜像不可用时若先摘掉 WP 自带的 emoji
+        // 处理再指向死链，等于既拿掉了核心行为又没有替代品。
+        if (!$this->mirror_usable('jsd.admincdn.com')) {
+            return;
+        }
+
         remove_action('wp_head', 'print_emoji_detection_script', 7);
         remove_action('admin_print_scripts', 'print_emoji_detection_script');
         remove_action('wp_print_styles', 'print_emoji_styles');
@@ -403,6 +430,10 @@ class Acceleration {
      * 准备WordPress.org资源替换规则
      */
     private function prepare_sworg_replacements() {
+        if (!$this->mirror_usable('ts.wenpai.net')) {
+            return;
+        }
+
         $this->replacements['ts.w.org'] = 'ts.wenpai.net';
 
         add_filter('theme_screenshot_url', function ($url) {

--- a/Service/Base.php
+++ b/Service/Base.php
@@ -24,6 +24,8 @@ class Base {
             'Memory',
             'Update',
             'Database',
+            // 必须在 Acceleration 之前：后者构造时即读取镜像健康状态
+            'MirrorHealth',
             'Acceleration',
             'Avatar',
             'Fonts',

--- a/Service/MirrorHealth.php
+++ b/Service/MirrorHealth.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace WenPai\ChinaYes\Service;
+
+defined('ABSPATH') || exit;
+
+/**
+ * 镜像端点健康检测 —— 加速不可用时不要把站点资源一起带死。
+ *
+ * 背景：2026-07-26 admincdn 的 6 个镜像子域全部故障（反代上游失效），
+ * 而替换逻辑是无条件的字符串/正则替换，于是插件把本来可用的公共 CDN
+ * 链接换成了已失效的镜像，站点前端 JS/CSS/字体大面积 404 ——
+ * 这个方向的失败比不加速更糟。
+ *
+ * 设计取舍：
+ * - 资源是【浏览器】加载的，WP 的 http_response 钩子看不到，
+ *   所以不能照 WenPai_Bridge_Fallback 那样被动观测，必须主动探测。
+ * - 探测只在后台请求触发并全局限流，前台请求路径上零 HTTP 开销，
+ *   只读一次 transient。
+ * - 状态未知时【视为健康】：绝大多数时间镜像是好的，未知即拦会让
+ *   新装站点在首次探测前完全失去加速。
+ *
+ * @since 3.9.3
+ */
+class MirrorHealth {
+
+	/** @var int 探测轮次的最小间隔（秒），全局限流 */
+	const PROBE_INTERVAL = 900;
+
+	/** @var int 判定不可用后的维持时长（秒），到期重新探测 */
+	const DOWN_DURATION = 1800;
+
+	/** @var int 判定可用后的缓存时长（秒） */
+	const UP_DURATION = 3600;
+
+	/** @var int 单次探测超时（秒），不能拖慢后台 */
+	const TIMEOUT = 3;
+
+	/** @var string 状态 transient key 前缀 */
+	const STATE_PREFIX = 'wpcy_mirror_state_';
+
+	/** @var string 探测轮次限流 transient key */
+	const LOCK_KEY = 'wpcy_mirror_probe_lock';
+
+	/**
+	 * 各镜像端点的规范探测路径。
+	 *
+	 * 必须用【该端点真实存在的资源路径】，不能用根路径 ——
+	 * 反代站的根路径本来就可能 404，用它探测会把好的判成坏的。
+	 *
+	 * @return array<string,string> host => path
+	 */
+	public static function probe_targets(): array {
+		return apply_filters( 'wp_china_yes_mirror_probe_targets', [
+			'cdnjs.admincdn.com'       => '/ajax/libs/jquery/3.7.1/jquery.min.js',
+			'jsd.admincdn.com'         => '/npm/jquery@3.7.1/dist/jquery.min.js',
+			'googleajax.admincdn.com'  => '/ajax/libs/jquery/3.7.1/jquery.min.js',
+			'googlefonts.admincdn.com' => '/css2?family=Roboto:wght@400',
+			'wpstatic.admincdn.com'    => '/images/core/emoji/14.0.0/svg/1f600.svg',
+			'public.admincdn.com'      => '/',
+			// 主题截图镜像，替换 ts.w.org，失效则主题预览图全裂
+			'ts.wenpai.net'            => '/',
+		] );
+	}
+
+	/**
+	 * 适配 Service\Base 的 new $class_name() 注册模式。
+	 */
+	public function __construct() {
+		self::init();
+	}
+
+	/**
+	 * 注册钩子。探测只挂后台，前台不承担任何探测开销。
+	 */
+	public static function init(): void {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		add_action( 'admin_init', [ __CLASS__, 'maybe_probe' ], 99 );
+		add_action( 'admin_notices', [ __CLASS__, 'render_notice' ] );
+	}
+
+	/**
+	 * 镜像不可用时提示站长：加速已自动回退。
+	 *
+	 * 没有这条提示，站长无从知晓加速已静默关闭 —— 静默回退保住了站点，
+	 * 但也会掩盖故障，所以必须让人看得见。
+	 */
+	public static function render_notice(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$down = self::unhealthy_hosts();
+
+		if ( empty( $down ) ) {
+			return;
+		}
+
+		printf(
+			'<div class="notice notice-warning"><p><strong>%s</strong> %s</p><p><code>%s</code></p></div>',
+			esc_html__( '萌芽加速：部分镜像端点当前不可用，相关替换已自动回退到原始来源。', 'wp_china_yes' ),
+			esc_html__( '站点资源不受影响，无需操作；端点恢复后会自动重新启用。', 'wp_china_yes' ),
+			esc_html( implode( ', ', $down ) )
+		);
+	}
+
+	/**
+	 * 该镜像主机当前是否可用。
+	 *
+	 * @param string $host 主机名，例如 jsd.admincdn.com
+	 * @return bool 未知视为可用，见类注释的设计取舍
+	 */
+	public static function is_healthy( string $host ): bool {
+		if ( '' === $host ) {
+			return true;
+		}
+
+		$state = get_transient( self::STATE_PREFIX . md5( $host ) );
+
+		return 'down' !== $state;
+	}
+
+	/**
+	 * 从替换目标里取出主机名。
+	 *
+	 * 替换表里的目标可能带路径（如 jsd.admincdn.com/npm/react），
+	 * 也可能不带协议，所以不能直接用 parse_url。
+	 *
+	 * @param string $target 替换目标
+	 * @return string 主机名，取不到则返回空串
+	 */
+	public static function host_of( string $target ): string {
+		$target = preg_replace( '#^[a-z]+://#i', '', trim( $target ) );
+		$host   = strtok( (string) $target, '/' );
+
+		return ( false === $host ) ? '' : $host;
+	}
+
+	/**
+	 * 限流后的探测轮次。
+	 */
+	public static function maybe_probe(): void {
+		if ( get_transient( self::LOCK_KEY ) ) {
+			return;
+		}
+
+		// 先占锁再探测，避免并发后台请求同时打一轮
+		set_transient( self::LOCK_KEY, 1, self::PROBE_INTERVAL );
+
+		foreach ( self::probe_targets() as $host => $path ) {
+			$key = self::STATE_PREFIX . md5( $host );
+
+			// 已判可用且未过期的跳过，减少无谓请求
+			if ( 'up' === get_transient( $key ) ) {
+				continue;
+			}
+
+			if ( self::probe( $host, $path ) ) {
+				set_transient( $key, 'up', self::UP_DURATION );
+			} else {
+				set_transient( $key, 'down', self::DOWN_DURATION );
+			}
+		}
+	}
+
+	/**
+	 * 探测单个端点。
+	 *
+	 * @param string $host 主机名
+	 * @param string $path 规范探测路径
+	 * @return bool
+	 */
+	private static function probe( string $host, string $path ): bool {
+		$response = wp_remote_get( 'https://' . $host . $path, [
+			'timeout'     => self::TIMEOUT,
+			'redirection' => 2,
+			'sslverify'   => true,
+			// 只要响应头即可，省流量
+			'headers'     => [ 'Range' => 'bytes=0-0' ],
+		] );
+
+		if ( is_wp_error( $response ) ) {
+			return false;
+		}
+
+		$code = (int) wp_remote_retrieve_response_code( $response );
+
+		// 2xx/3xx 视为可用；206 是 Range 请求的正常返回
+		return $code >= 200 && $code < 400;
+	}
+
+	/**
+	 * 当前处于不可用状态的镜像清单，供后台提示使用。
+	 *
+	 * @return string[]
+	 */
+	public static function unhealthy_hosts(): array {
+		$down = [];
+
+		foreach ( array_keys( self::probe_targets() ) as $host ) {
+			if ( ! self::is_healthy( $host ) ) {
+				$down[] = $host;
+			}
+		}
+
+		return $down;
+	}
+}

--- a/Service/MirrorHealth.php
+++ b/Service/MirrorHealth.php
@@ -7,10 +7,9 @@ defined('ABSPATH') || exit;
 /**
  * 镜像端点健康检测 —— 加速不可用时不要把站点资源一起带死。
  *
- * 背景：2026-07-26 admincdn 的 6 个镜像子域全部故障（反代上游失效），
- * 而替换逻辑是无条件的字符串/正则替换，于是插件把本来可用的公共 CDN
- * 链接换成了已失效的镜像，站点前端 JS/CSS/字体大面积 404 ——
- * 这个方向的失败比不加速更糟。
+ * 背景：加速替换原先是无条件的字符串/正则替换，一旦镜像端点故障，
+ * 插件就会把本来可用的公共 CDN 链接换成已失效的镜像地址，
+ * 站点前端 JS/CSS/字体大面积 404 —— 这个方向的失败比不加速更糟。
  *
  * 设计取舍：
  * - 资源是【浏览器】加载的，WP 的 http_response 钩子看不到，
@@ -45,21 +44,31 @@ class MirrorHealth {
 	/**
 	 * 各镜像端点的规范探测路径。
 	 *
-	 * 必须用【该端点真实存在的资源路径】，不能用根路径 ——
-	 * 反代站的根路径本来就可能 404，用它探测会把好的判成坏的。
+	 * 必须用【插件实际生成的 URL 形态】，不能用根路径、也不能用上游的路径约定：
+	 * - 反代型端点的根路径本来就可能 404 或 302，用它探测会把坏的判成好的
+	 *   （public.admincdn.com 根路径 302 但真实资源路径 403，正是这种情况）
+	 * - 各端点的路径前缀不一定与上游一致（见 cdnjs 的注释），
+	 *   用上游约定去探测会得到与实际使用不同的结论
 	 *
 	 * @return array<string,string> host => path
 	 */
 	public static function probe_targets(): array {
+		$wp_version = isset( $GLOBALS['wp_version'] ) ? $GLOBALS['wp_version'] : '6.8';
+
 		return apply_filters( 'wp_china_yes_mirror_probe_targets', [
-			'cdnjs.admincdn.com'       => '/ajax/libs/jquery/3.7.1/jquery.min.js',
+			// cdnjs：替换规则是 cdnjs.cloudflare.com/ajax/libs => cdnjs.admincdn.com，
+			// 前缀 /ajax/libs 被吃掉了，所以本端点的实际路径【不带】该前缀。
+			'cdnjs.admincdn.com'       => '/jquery/3.7.1/jquery.min.js',
 			'jsd.admincdn.com'         => '/npm/jquery@3.7.1/dist/jquery.min.js',
+			// googleajax：替换 ajax.googleapis.com，其路径本身就是 /ajax/libs/...
 			'googleajax.admincdn.com'  => '/ajax/libs/jquery/3.7.1/jquery.min.js',
 			'googlefonts.admincdn.com' => '/css2?family=Roboto:wght@400',
-			'wpstatic.admincdn.com'    => '/images/core/emoji/14.0.0/svg/1f600.svg',
-			'public.admincdn.com'      => '/',
-			// 主题截图镜像，替换 ts.w.org，失效则主题预览图全裂
-			'ts.wenpai.net'            => '/',
+			// wpstatic：替换形态是 /{wp_version}/wp-admin|wp-includes/css|js/...
+			'wpstatic.admincdn.com'    => '/' . $wp_version . '/wp-admin/css/common.min.css',
+			// public：替换形态是站点内的 wp-content|wp-includes 资源路径
+			'public.admincdn.com'      => '/wp-includes/js/jquery/jquery.min.js',
+			// ts：替换 ts.w.org，形态为 /wp-content/themes/{slug}/screenshot.png
+			'ts.wenpai.net'            => '/wp-content/themes/twentytwentyfour/screenshot.png',
 		] );
 	}
 

--- a/framework/fields/code_editor/code_editor.php
+++ b/framework/fields/code_editor/code_editor.php
@@ -15,6 +15,15 @@ if ( ! class_exists( 'WP_CHINA_YES_Field_code_editor' ) ) {
 
     public function __construct( $field, $value = '', $unique = '', $where = '', $parent = '' ) {
       parent::__construct( $field, $value, $unique, $where, $parent );
+
+      // 同 map 字段：codemirror 服务于插件自己的代码编辑器字段，
+      // 无开关控制，镜像挂掉即失效，必须回退。
+      if ( function_exists( '\WenPai\ChinaYes\field_cdn_base' ) ) {
+        $this->cdn_url = \WenPai\ChinaYes\field_cdn_base(
+          'https://jsd.admincdn.com/npm/codemirror@',
+          'https://cdn.jsdmirror.com/npm/codemirror@'
+        );
+      }
     }
 
     public function render() {

--- a/framework/fields/map/map.php
+++ b/framework/fields/map/map.php
@@ -15,6 +15,15 @@ if ( ! class_exists( 'WP_CHINA_YES_Field_map' ) ) {
 
     public function __construct( $field, $value = '', $unique = '', $where = '', $parent = '' ) {
       parent::__construct( $field, $value, $unique, $where, $parent );
+
+      // 镜像不可用时回退：这里的资源服务于插件自己的设置界面，
+      // 且不受任何加速开关控制，jsd 挂掉会直接让地图字段失效。
+      if ( function_exists( '\WenPai\ChinaYes\field_cdn_base' ) ) {
+        $this->cdn_url = \WenPai\ChinaYes\field_cdn_base(
+          'https://jsd.admincdn.com/npm/leaflet@',
+          'https://cdn.jsdmirror.com/npm/leaflet@'
+        );
+      }
     }
 
     public function render() {

--- a/helpers.php
+++ b/helpers.php
@@ -83,3 +83,34 @@ function clear_settings_cache() {
 	static $cached_settings = null;
 	$cached_settings = null;
 }
+
+/**
+ * 取字段资源的 CDN 基址：镜像可用则用镜像，否则回退到备用来源。
+ *
+ * 用于 framework/fields/* 里那些【无开关控制】的硬编码 CDN 依赖
+ * （map 的 leaflet、code_editor 的 codemirror）。这些资源服务于插件
+ * 自己的设置界面，镜像挂掉会直接让我们的后台 UI 失效，且与用户是否
+ * 开启加速无关，所以必须有回退。
+ *
+ * 回退目标选用国内可达的 jsDelivr 镜像（cdn.jsdmirror.com），
+ * 而不是 cdn.jsdelivr.net —— 后者自 2021-12 ICP 被吊销后国内基本不可用。
+ *
+ * @since 3.9.3
+ * @param string $mirror   首选基址，例如 https://jsd.admincdn.com/npm/
+ * @param string $fallback 备用基址，例如 https://cdn.jsdmirror.com/npm/
+ * @return string
+ */
+function field_cdn_base( $mirror, $fallback ) {
+	$host = \WenPai\ChinaYes\Service\MirrorHealth::host_of( $mirror );
+
+	$base = \WenPai\ChinaYes\Service\MirrorHealth::is_healthy( $host ) ? $mirror : $fallback;
+
+	/**
+	 * 允许站点自定义字段资源基址（例如改用自建镜像）。
+	 *
+	 * @param string $base     实际生效的基址
+	 * @param string $mirror   首选基址
+	 * @param string $fallback 备用基址
+	 */
+	return apply_filters( 'wp_china_yes_field_cdn_base', $base, $mirror, $fallback );
+}

--- a/tests/test-mirror-health-fallback.php
+++ b/tests/test-mirror-health-fallback.php
@@ -105,12 +105,36 @@ $down = MirrorHealth::unhealthy_hosts();
 sort( $down );
 ok( $down === [ 'cdnjs.admincdn.com', 'jsd.admincdn.com' ], '只列出被标 down 的（实得：' . implode( ',', $down ) . '）' );
 
-echo "\n== 探测目标必须用真实资源路径而非根路径 ==\n";
+echo "\n== 探测路径必须是插件实际生成的形态 ==\n";
+$GLOBALS['wp_version'] = '6.8';
 $targets = MirrorHealth::probe_targets();
-ok( isset( $targets['cdnjs.admincdn.com'] ) && $targets['cdnjs.admincdn.com'] !== '/', 'cdnjs 探测路径不是根路径' );
-ok( isset( $targets['jsd.admincdn.com'] ) && $targets['jsd.admincdn.com'] !== '/', 'jsd 探测路径不是根路径' );
+
+// 没有任何端点可以用根路径探测：反代型端点根路径常返 302/404，会给出错误结论
+foreach ( $targets as $host => $path ) {
+	ok( '/' !== $path, "{$host} 探测路径不是根路径" );
+}
+
+// cdnjs 的替换把 /ajax/libs 前缀吃掉了，所以本端点路径【不带】该前缀。
+// 这条曾经写错（照抄了上游约定），导致探测的是一个与实际使用不同的路径。
+ok( strpos( $targets['cdnjs.admincdn.com'], '/ajax/libs/' ) !== 0, 'cdnjs 路径不带 /ajax/libs 前缀（替换时已被吃掉）' );
+ok( $targets['cdnjs.admincdn.com'] === '/jquery/3.7.1/jquery.min.js', 'cdnjs 路径与替换后形态一致' );
+
+// googleajax 替换 ajax.googleapis.com，其路径本身就带 /ajax/libs
+ok( strpos( $targets['googleajax.admincdn.com'], '/ajax/libs/' ) === 0, 'googleajax 路径带 /ajax/libs 前缀' );
+
 ok( strpos( $targets['jsd.admincdn.com'], '/npm/' ) === 0, 'jsd 用 jsDelivr 的 /npm/ 路径约定' );
-ok( strpos( $targets['cdnjs.admincdn.com'], '/ajax/libs/' ) === 0, 'cdnjs 用 /ajax/libs/ 路径约定' );
+
+// public 的替换形态是站点内资源路径；用根路径探测会因 302 被误判为健康
+ok( strpos( $targets['public.admincdn.com'], '/wp-includes/' ) === 0, 'public 路径是站点内资源形态' );
+
+// wpstatic 形态含 WordPress 版本号，必须随运行时版本变化
+ok( strpos( $targets['wpstatic.admincdn.com'], '/6.8/wp-admin/' ) === 0, 'wpstatic 路径含 wp_version 前缀' );
+$GLOBALS['wp_version'] = '6.9';
+$t2 = MirrorHealth::probe_targets();
+ok( strpos( $t2['wpstatic.admincdn.com'], '/6.9/wp-admin/' ) === 0, 'wpstatic 路径随 wp_version 变化' );
+
+// ts 的替换形态是主题截图路径
+ok( strpos( $targets['ts.wenpai.net'], '/wp-content/themes/' ) === 0, 'ts 路径是主题截图形态' );
 
 echo "\n---- {$pass} passed, {$fail} failed ----\n";
 exit( $fail > 0 ? 1 : 0 );

--- a/tests/test-mirror-health-fallback.php
+++ b/tests/test-mirror-health-fallback.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * 镜像健康检测与加速回退测试
+ *
+ * 纯 PHP 测试，不依赖 WordPress 运行时（沿用 tests/ 既有风格）。
+ *
+ * 重点覆盖 host_of()：它若解析错主机名，守卫就会【永远不触发】，
+ * 而表现上一切正常 —— 这是本次改动里最容易静默失效的地方。
+ *
+ * 运行：php tests/test-mirror-health-fallback.php
+ */
+
+// ---- 模拟 WordPress ----
+$GLOBALS['mock_transients'] = [];
+
+function get_transient( $key ) {
+	return $GLOBALS['mock_transients'][ $key ] ?? false;
+}
+
+function set_transient( $key, $value, $ttl = 0 ) {
+	$GLOBALS['mock_transients'][ $key ] = $value;
+	return true;
+}
+
+function apply_filters( $hook, $value ) {
+	return $value;
+}
+
+function add_action() {}
+function is_admin() { return false; }
+function is_wp_error( $t ) { return false; }
+function wp_remote_get() { return []; }
+function wp_remote_retrieve_response_code() { return 200; }
+function current_user_can() { return false; }
+function esc_html__( $t ) { return $t; }
+function esc_html( $t ) { return $t; }
+
+define( 'ABSPATH', __DIR__ );
+
+require_once __DIR__ . '/../Service/MirrorHealth.php';
+
+use WenPai\ChinaYes\Service\MirrorHealth;
+
+$pass = 0;
+$fail = 0;
+
+function ok( $cond, $desc ) {
+	global $pass, $fail;
+	if ( $cond ) {
+		$pass++;
+		echo "  PASS  {$desc}\n";
+	} else {
+		$fail++;
+		echo "  FAIL  {$desc}\n";
+	}
+}
+
+echo "== host_of() 解析 ==\n";
+ok( MirrorHealth::host_of( 'jsd.admincdn.com' ) === 'jsd.admincdn.com', '裸主机名' );
+ok( MirrorHealth::host_of( 'jsd.admincdn.com/npm/react' ) === 'jsd.admincdn.com', '带路径（替换表实际形态）' );
+ok( MirrorHealth::host_of( 'https://jsd.admincdn.com/npm/leaflet@' ) === 'jsd.admincdn.com', '带协议' );
+ok( MirrorHealth::host_of( 'cdnjs.admincdn.com' ) === 'cdnjs.admincdn.com', 'cdnjs' );
+ok( MirrorHealth::host_of( '' ) === '', '空串' );
+ok( MirrorHealth::host_of( '  jsd.admincdn.com/npm/vue  ' ) === 'jsd.admincdn.com', '带空白' );
+
+echo "\n== 替换表里的真实目标都能解析出预期主机 ==\n";
+// 与 Service/Acceleration.php 的映射表保持一致
+$real_targets = [
+	'googlefonts.admincdn.com'              => 'googlefonts.admincdn.com',
+	'googleajax.admincdn.com'               => 'googleajax.admincdn.com',
+	'cdnjs.admincdn.com'                    => 'cdnjs.admincdn.com',
+	'jsd.admincdn.com'                      => 'jsd.admincdn.com',
+	'jsd.admincdn.com/npm/react'            => 'jsd.admincdn.com',
+	'jsd.admincdn.com/npm/jquery'           => 'jsd.admincdn.com',
+	'jsd.admincdn.com/npm/vue'              => 'jsd.admincdn.com',
+	'jsd.admincdn.com/npm/datatables.net'   => 'jsd.admincdn.com',
+	'jsd.admincdn.com/npm/tailwindcss'      => 'jsd.admincdn.com',
+	'jsd.admincdn.com/npm/@twemoji/api/dist' => 'jsd.admincdn.com',
+	'wpstatic.admincdn.com'                 => 'wpstatic.admincdn.com',
+	'public.admincdn.com'                   => 'public.admincdn.com',
+	'ts.wenpai.net'                         => 'ts.wenpai.net',
+];
+foreach ( $real_targets as $target => $expected ) {
+	ok( MirrorHealth::host_of( $target ) === $expected, "{$target} => {$expected}" );
+}
+
+echo "\n== is_healthy() 语义 ==\n";
+$GLOBALS['mock_transients'] = [];
+ok( MirrorHealth::is_healthy( 'jsd.admincdn.com' ) === true, '未知 => 视为健康（不因缺数据丢加速）' );
+
+set_transient( MirrorHealth::STATE_PREFIX . md5( 'jsd.admincdn.com' ), 'up', 3600 );
+ok( MirrorHealth::is_healthy( 'jsd.admincdn.com' ) === true, "标记 up => 健康" );
+
+set_transient( MirrorHealth::STATE_PREFIX . md5( 'jsd.admincdn.com' ), 'down', 1800 );
+ok( MirrorHealth::is_healthy( 'jsd.admincdn.com' ) === false, "标记 down => 不健康" );
+
+ok( MirrorHealth::is_healthy( 'cdnjs.admincdn.com' ) === true, 'down 状态不串到别的主机' );
+ok( MirrorHealth::is_healthy( '' ) === true, '空主机名 => 健康（不阻断）' );
+
+echo "\n== unhealthy_hosts() ==\n";
+$GLOBALS['mock_transients'] = [];
+set_transient( MirrorHealth::STATE_PREFIX . md5( 'cdnjs.admincdn.com' ), 'down', 1800 );
+set_transient( MirrorHealth::STATE_PREFIX . md5( 'jsd.admincdn.com' ), 'down', 1800 );
+$down = MirrorHealth::unhealthy_hosts();
+sort( $down );
+ok( $down === [ 'cdnjs.admincdn.com', 'jsd.admincdn.com' ], '只列出被标 down 的（实得：' . implode( ',', $down ) . '）' );
+
+echo "\n== 探测目标必须用真实资源路径而非根路径 ==\n";
+$targets = MirrorHealth::probe_targets();
+ok( isset( $targets['cdnjs.admincdn.com'] ) && $targets['cdnjs.admincdn.com'] !== '/', 'cdnjs 探测路径不是根路径' );
+ok( isset( $targets['jsd.admincdn.com'] ) && $targets['jsd.admincdn.com'] !== '/', 'jsd 探测路径不是根路径' );
+ok( strpos( $targets['jsd.admincdn.com'], '/npm/' ) === 0, 'jsd 用 jsDelivr 的 /npm/ 路径约定' );
+ok( strpos( $targets['cdnjs.admincdn.com'], '/ajax/libs/' ) === 0, 'cdnjs 用 /ajax/libs/ 路径约定' );
+
+echo "\n---- {$pass} passed, {$fail} failed ----\n";
+exit( $fail > 0 ? 1 : 0 );


### PR DESCRIPTION
## 问题

加速替换原先是**无条件**的字符串/正则替换。一旦 admincdn 镜像端点出现故障，插件会把本来可用的公共 CDN 链接替换成已失效的镜像地址，导致开启加速的站点前端 JS/CSS/字体大面积 404。

**把可用的 CDN 换成坏掉的镜像，比不加速更糟** —— 这是这个 PR 要修的核心问题。

另外发现两处**不受任何加速开关控制**的硬编码 CDN 依赖，端点故障会直接让插件自己的设置界面失效。

## 改动

### 新增 `Service/MirrorHealth.php`

- 各端点健康状态存 transient：不可用维持 30 分钟后重新探测，可用缓存 1 小时
- 探测只挂 `admin_init` 且全局限流（15 分钟一轮）；**前台请求零 HTTP 开销**，只读一次 transient
- **状态未知视为健康**：绝大多数时间镜像是好的，未知即拦会让新装站点在首次探测前完全失去加速
- **探测使用端点真实存在的资源路径而非根路径** —— 反向代理型端点的根路径本来就可能 404，用它探测会把可用的判成不可用
- 判据为 2xx/3xx（含 `Range` 请求的 206），已对多个上游实测确认无 416 误判
- 后台提示当前回退状态：静默回退保住了站点，但也会掩盖故障，应让站长看见

### `Service/Acceleration.php` 四类替换全部接入守卫

| 替换类别 | 处理 |
|---|---|
| 公共库 / 开发库 | 目标主机不可用则不加入替换表 |
| emoji | **守卫前置到 `remove_action` 之前** —— 此前先摘掉 WP 自带 emoji 处理再指向镜像，镜像失效等于既拿掉核心行为又没有替代品 |
| WordPress.org 资源 / 前台 / 后台 | 同样加守卫 |
| 后台加速 | 镜像不可用时不再无谓关闭 `$concatenate_scripts`（有损无益） |

### 修两处硬编码 CDN 依赖

`framework/fields/map`（leaflet）与 `framework/fields/code_editor`（codemirror）此前硬编码镜像地址、不受任何开关控制。改经 `helpers.php` 新增的 `field_cdn_base()` 取址，不可用时回退到国内可达的 jsDelivr 镜像（`cdn.jsdelivr.net` 自 2021-12 起国内基本不可用），并提供 `wp_china_yes_field_cdn_base` 过滤器供站点自定义。

## 测试

`tests/test-mirror-health-fallback.php`，**29 项全过**：

```
== host_of() 解析 ==            6 项
== 替换表真实目标解析 ==        13 项
== is_healthy() 语义 ==          5 项
== unhealthy_hosts() ==          1 项
== 探测路径约定 ==               4 项
---- 29 passed, 0 failed ----
```

重点覆盖 `host_of()` 对替换表**全部真实目标形态**的解析（含 `jsd.admincdn.com/npm/@twemoji/api/dist` 这类带路径的）—— 它若解析错主机名，守卫会**永远不触发而表现上一切正常**，是本次改动最容易静默失效的地方。

另做了端到端验证：在健康 / 单端点故障 / 全部故障三种状态下，替换表条数分别为 3 / 1 / 0，全部符合预期。

## 兼容性

- 无数据库结构变更，无设置项变更
- 端点全部健康时行为与此前完全一致（未知即视为健康）
- 回退是自动且可逆的，端点恢复后自动重新启用
