### PR TITLE
feat!: 废弃并移除「前台加速」(public.admincdn.com)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `WP-China-Yes` will be documented in this file.
 
 ## 未发布
 
+### 移除
+- **废弃并移除「前台加速」（`public.admincdn.com`）**。该功能把站点自己的
+  `/wp-content|/wp-includes` 路径整体改写到一个共享端点，但 **`wp-content` 是站点自有内容**
+  （主题、插件、上传文件），共享端点不可能持有各站的这些文件 —— 结果要么 404，要么更糟：
+  返回别的站的同名文件，使站点静默加载到不属于它的 CSS/JS/图片。**返回错内容比返回 404 更有害。**
+  `wp-includes` 部分（核心文件、各站相同）本可保留，但已由「后台加速」覆盖，无需第二条链路。
+  该选项此前**默认关闭**，绝大多数站点不受影响；已启用的站点在后台访问时自动摘除该项
+  （`Service/Migration.php`），其余加速项不受影响。
+
 ### 修复
 - **加速镜像不可用时不再把站点资源一起带死**：`admincdn` 各镜像端点新增健康检测
   （`Service/MirrorHealth.php`），端点不可用时跳过替换、保留原始公共 CDN 链接，

--- a/Service/Acceleration.php
+++ b/Service/Acceleration.php
@@ -56,10 +56,6 @@ class Acceleration {
             $this->prepare_admin_replacements();
         }
 
-        if ($this->has_frontend_acceleration()) {
-            $this->prepare_frontend_replacements();
-        }
-
         if ($this->has_public_library_acceleration()) {
             $this->prepare_public_library_replacements();
         }
@@ -79,14 +75,6 @@ class Acceleration {
     private function has_admin_acceleration() {
         return !empty($this->settings['admincdn']) && 
                in_array('admin', (array) $this->settings['admincdn']);
-    }
-
-    /**
-     * 检查是否启用前台加速
-     */
-    private function has_frontend_acceleration() {
-        return !empty($this->settings['admincdn_files']) && 
-               in_array('frontend', (array) $this->settings['admincdn_files']);
     }
 
     /**
@@ -313,15 +301,21 @@ class Acceleration {
     }
 
     /**
-     * 准备前台替换规则
+     * 前台加速（public.admincdn.com）已于 3.9.3 废弃并移除。
+     *
+     * 原实现把站点自己的 /wp-content|/wp-includes 路径整体改写到该共享端点：
+     *   $this->regex_patterns[$pattern] = 'https://public.admincdn.com/$0';
+     *
+     * 但 wp-content 是**站点自有内容**（主题、插件、上传文件），一个共享端点
+     * 不可能持有各站的这些文件。它要么 404，要么更糟 —— 返回别的站的同名文件，
+     * 使站点静默加载到不属于它的 CSS/JS/图片。返回错内容比返回 404 更有害。
+     *
+     * wp-includes 部分（核心文件、各站相同）本可保留，但它与 wp-admin 一起
+     * 已由「后台加速」（wpstatic）覆盖，无需第二条链路。
+     *
+     * 该选项此前默认关闭，故绝大多数站点不受影响；已启用的站点由
+     * Service/Migration.php 的 migrate_deprecate_frontend_acceleration() 自动摘除。
      */
-    private function prepare_frontend_replacements() {
-        if (in_array('frontend', (array) $this->settings['admincdn_files'])
-            && $this->mirror_usable('public.admincdn.com')) {
-            $pattern = '#(?<=[(\"\'])(?:' . quotemeta(home_url()) . ')?/(?:((?:wp-content|wp-includes)[^\"\')]+\.(css|js)[^\"\')]+))(?=[\"\')])#';
-            $this->regex_patterns[$pattern] = 'https://public.admincdn.com/$0';
-        }
-    }
 
     /**
      * 准备公共库替换规则

--- a/Service/Migration.php
+++ b/Service/Migration.php
@@ -13,6 +13,48 @@ class Migration {
 	public function __construct() {
 		$this->settings = get_settings();
 		add_action( 'admin_init', [ $this, 'migrate_windfonts_settings' ] );
+		add_action( 'admin_init', [ $this, 'migrate_deprecate_frontend_acceleration' ] );
+	}
+
+	/**
+	 * 摘除已废弃的「前台加速」选项（3.9.3）。
+	 *
+	 * public.admincdn.com 是共享端点，无法持有各站自有的 wp-content 内容；
+	 * 保留该选项只会让站点继续把资源指向一个必然取不到正确文件的地址。
+	 * 详见 Service/Acceleration.php 中的废弃说明。
+	 *
+	 * 该选项此前默认关闭，因此绝大多数站点此迁移是空操作。
+	 */
+	public function migrate_deprecate_frontend_acceleration() {
+		$current_settings = get_option( 'wp_china_yes', [] );
+
+		if ( ! is_array( $current_settings ) || empty( $current_settings['admincdn_files'] ) ) {
+			return;
+		}
+
+		$files = (array) $current_settings['admincdn_files'];
+
+		// checkbox 字段可能是 ['frontend'] 或 ['frontend' => 'frontend'] 两种形态，都要处理
+		$had_frontend = in_array( 'frontend', $files, true ) || array_key_exists( 'frontend', $files );
+
+		if ( ! $had_frontend ) {
+			return;
+		}
+
+		$files = array_filter(
+			$files,
+			static function ( $value, $key ) {
+				return 'frontend' !== $value && 'frontend' !== $key;
+			},
+			ARRAY_FILTER_USE_BOTH
+		);
+
+		$current_settings['admincdn_files'] = $files;
+		update_option( 'wp_china_yes', $current_settings );
+
+		if ( function_exists( '\WenPai\ChinaYes\clear_settings_cache' ) ) {
+			\WenPai\ChinaYes\clear_settings_cache();
+		}
 	}
 
 	public function migrate_windfonts_settings() {

--- a/Service/MirrorHealth.php
+++ b/Service/MirrorHealth.php
@@ -65,8 +65,6 @@ class MirrorHealth {
 			'googlefonts.admincdn.com' => '/css2?family=Roboto:wght@400',
 			// wpstatic：替换形态是 /{wp_version}/wp-admin|wp-includes/css|js/...
 			'wpstatic.admincdn.com'    => '/' . $wp_version . '/wp-admin/css/common.min.css',
-			// public：替换形态是站点内的 wp-content|wp-includes 资源路径
-			'public.admincdn.com'      => '/wp-includes/js/jquery/jquery.min.js',
 			// ts：替换 ts.w.org，形态为 /wp-content/themes/{slug}/screenshot.png
 			'ts.wenpai.net'            => '/wp-content/themes/twentytwentyfour/screenshot.png',
 		] );

--- a/Service/Setting.php
+++ b/Service/Setting.php
@@ -153,14 +153,15 @@ private function get_settings_page_url() {
                 'title'    => '文件加速',
                 'inline'   => true,
                 'options'  => [
+                    // 'frontend'（前台加速）已于 3.9.3 废弃移除：
+                    // public.admincdn.com 是共享端点，不可能持有各站自有的
+                    // wp-content 内容，详见 Service/Acceleration.php 的废弃说明。
                     'admin'       => '后台加速',
-                    'frontend'    => '前台加速',
                     'emoji'       => 'Emoji加速',
                     'sworg'       => '预览加速',
                 ],
                 'default'  => [
                     'admin'       => 'admin',
-                    'frontend'    => '',
                     'emoji'       => 'emoji',
                     'sworg'       => '',
                 ],

--- a/tests/test-deprecate-frontend-acceleration.php
+++ b/tests/test-deprecate-frontend-acceleration.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * 「前台加速」废弃迁移测试
+ *
+ * 纯 PHP，不依赖 WordPress 运行时（沿用 tests/ 既有风格）。
+ *
+ * 这是本次改动里**唯一会写入站点数据**的部分，必须验：
+ * - checkbox 字段有 ['frontend'] 和 ['frontend' => 'frontend'] 两种形态，都要能摘除
+ * - 不能顺手动到 admin / emoji / sworg
+ * - 没有 frontend 的站点必须是空操作（不产生无谓写入）
+ *
+ * 运行：php tests/test-deprecate-frontend-acceleration.php
+ */
+
+namespace {
+$GLOBALS['mock_option']  = [];
+$GLOBALS['write_count']  = 0;
+
+function get_option( $key, $default = false ) {
+	return $GLOBALS['mock_option'][ $key ] ?? $default;
+}
+
+function update_option( $key, $value ) {
+	$GLOBALS['mock_option'][ $key ] = $value;
+	$GLOBALS['write_count']++;
+	return true;
+}
+
+function get_site_option( $key, $default = false ) { return get_option( $key, $default ); }
+function is_multisite() { return false; }
+function add_action() {}
+function wp_parse_args( $args, $defaults = [] ) { return array_merge( $defaults, (array) $args ); }
+
+define( 'ABSPATH', __DIR__ );
+}
+
+// Migration 依赖 get_settings()，给个最小实现
+namespace WenPai\ChinaYes {
+	function get_settings() { return \get_option( 'wp_china_yes', [] ); }
+	function clear_settings_cache() {}
+}
+
+namespace {
+	require_once __DIR__ . '/../Service/Migration.php';
+
+	use WenPai\ChinaYes\Service\Migration;
+
+	$pass = 0;
+	$fail = 0;
+
+	function ok( $cond, $desc ) {
+		global $pass, $fail;
+		if ( $cond ) { $pass++; echo "  PASS  {$desc}\n"; }
+		else { $fail++; echo "  FAIL  {$desc}\n"; }
+	}
+
+	function run_migration( array $saved ): array {
+		$GLOBALS['mock_option']['wp_china_yes'] = $saved;
+		$GLOBALS['write_count'] = 0;
+		$m = new Migration();
+		$m->migrate_deprecate_frontend_acceleration();
+		return $GLOBALS['mock_option']['wp_china_yes'];
+	}
+
+	echo "== 形态一：索引数组 ['admin','frontend','emoji'] ==\n";
+	$r = run_migration( [ 'admincdn_files' => [ 'admin', 'frontend', 'emoji' ] ] );
+	$files = array_values( $r['admincdn_files'] );
+	sort( $files );
+	ok( $files === [ 'admin', 'emoji' ], 'frontend 已摘除，admin/emoji 保留（实得：' . implode( ',', $files ) . '）' );
+	ok( $GLOBALS['write_count'] === 1, '发生了一次写入' );
+
+	echo "\n== 形态二：关联数组 ['admin'=>'admin','frontend'=>'frontend'] ==\n";
+	$r = run_migration( [ 'admincdn_files' => [ 'admin' => 'admin', 'frontend' => 'frontend', 'emoji' => 'emoji' ] ] );
+	ok( ! array_key_exists( 'frontend', $r['admincdn_files'] ), 'frontend 键已摘除' );
+	ok( array_key_exists( 'admin', $r['admincdn_files'] ), 'admin 键保留' );
+	ok( array_key_exists( 'emoji', $r['admincdn_files'] ), 'emoji 键保留' );
+
+	echo "\n== 形态三：关联数组里 frontend 值为空串（默认关闭的存量形态）==\n";
+	$r = run_migration( [ 'admincdn_files' => [ 'admin' => 'admin', 'frontend' => '', 'emoji' => 'emoji' ] ] );
+	ok( ! array_key_exists( 'frontend', $r['admincdn_files'] ), 'frontend 键仍被摘除（键存在即清理）' );
+
+	echo "\n== 不该动的情况：没有 frontend ==\n";
+	$r = run_migration( [ 'admincdn_files' => [ 'admin', 'emoji' ] ] );
+	ok( $GLOBALS['write_count'] === 0, '空操作，不产生无谓写入' );
+	ok( array_values( $r['admincdn_files'] ) === [ 'admin', 'emoji' ], '设置未被改动' );
+
+	echo "\n== 不该动的情况：admincdn_files 不存在 / 非数组 ==\n";
+	$r = run_migration( [ 'store' => 'wenpai' ] );
+	ok( $GLOBALS['write_count'] === 0, 'admincdn_files 缺失时空操作' );
+
+	$GLOBALS['mock_option']['wp_china_yes'] = 'corrupted-string';
+	$GLOBALS['write_count'] = 0;
+	$m = new Migration();
+	$m->migrate_deprecate_frontend_acceleration();
+	ok( $GLOBALS['write_count'] === 0, '设置序列化损坏时不写入（不放大已有损坏）' );
+
+	echo "\n== 其他加速项不受影响 ==\n";
+	$r = run_migration( [
+		'admincdn'        => [ 'admin' ],
+		'admincdn_public' => [ 'googlefonts' ],
+		'admincdn_files'  => [ 'admin', 'frontend', 'emoji', 'sworg' ],
+		'admincdn_dev'    => [ 'jquery' ],
+	] );
+	ok( $r['admincdn'] === [ 'admin' ], 'admincdn 未动' );
+	ok( $r['admincdn_public'] === [ 'googlefonts' ], 'admincdn_public 未动' );
+	ok( $r['admincdn_dev'] === [ 'jquery' ], 'admincdn_dev 未动' );
+	$files = array_values( $r['admincdn_files'] );
+	sort( $files );
+	ok( $files === [ 'admin', 'emoji', 'sworg' ], 'admincdn_files 只少了 frontend（实得：' . implode( ',', $files ) . '）' );
+
+	echo "\n---- {$pass} passed, {$fail} failed ----\n";
+	exit( $fail > 0 ? 1 : 0 );
+}

--- a/tests/test-mirror-health-fallback.php
+++ b/tests/test-mirror-health-fallback.php
@@ -77,7 +77,6 @@ $real_targets = [
 	'jsd.admincdn.com/npm/tailwindcss'      => 'jsd.admincdn.com',
 	'jsd.admincdn.com/npm/@twemoji/api/dist' => 'jsd.admincdn.com',
 	'wpstatic.admincdn.com'                 => 'wpstatic.admincdn.com',
-	'public.admincdn.com'                   => 'public.admincdn.com',
 	'ts.wenpai.net'                         => 'ts.wenpai.net',
 ];
 foreach ( $real_targets as $target => $expected ) {
@@ -124,8 +123,8 @@ ok( strpos( $targets['googleajax.admincdn.com'], '/ajax/libs/' ) === 0, 'googlea
 
 ok( strpos( $targets['jsd.admincdn.com'], '/npm/' ) === 0, 'jsd 用 jsDelivr 的 /npm/ 路径约定' );
 
-// public 的替换形态是站点内资源路径；用根路径探测会因 302 被误判为健康
-ok( strpos( $targets['public.admincdn.com'], '/wp-includes/' ) === 0, 'public 路径是站点内资源形态' );
+// public.admincdn.com 于 3.9.3 随「前台加速」一并废弃，不应再出现在探测表里
+ok( ! isset( $targets['public.admincdn.com'] ), 'public 已从探测目标移除（前台加速已废弃）' );
 
 // wpstatic 形态含 WordPress 版本号，必须随运行时版本变化
 ok( strpos( $targets['wpstatic.admincdn.com'], '/6.8/wp-admin/' ) === 0, 'wpstatic 路径含 wp_version 前缀' );


### PR DESCRIPTION
> **叠加 PR**：base 是 #137（`fix/admincdn-mirror-fallback`），不是 `master`。
> 这样本 PR 的 diff 只含「废弃前台加速」这一件事——#137 是 bug 修复可以先合，本 PR 是产品行为变更，值得单独评审。

## 为什么是移除而不是修

`public.admincdn.com` 是一个**共享端点**，而「前台加速」的替换规则把站点自己的 `/wp-content|/wp-includes` 路径整体改写到它上面：

```php
$this->regex_patterns[$pattern] = 'https://public.admincdn.com/$0';
// $0 形如 /wp-content/themes/xxx/style.css 或 /wp-includes/js/...
```

**`wp-content` 是站点自有内容**（主题、插件、上传文件）。一个共享端点不可能持有各站的这些文件，结果只有两种，都不可接受：

| 结果 | 后果 |
|---|---|
| 取不到 → 404 | 站点样式/脚本/图片直接缺失 |
| 取到同名文件 → **返回别的站的内容** | 站点静默加载到不属于它的资源 |

**后者比 404 更有害**：没有任何报错，排查时也不会怀疑到 CDN 替换。

`wp-includes`（WordPress 核心文件、各站相同）本身可由共享端点服务，但它与 `wp-admin` 一起**已由「后台加速」(`wpstatic.admincdn.com`) 覆盖**，没有保留第二条链路的理由。

所以这不是配置故障，是设计上站不住——修不如移除。

## 改动

| 文件 | 改动 |
|---|---|
| `Service/Acceleration.php` | 移除 `prepare_frontend_replacements()` 与 `has_frontend_acceleration()`，原位置留下废弃说明（解释为什么不是修而是移除） |
| `Service/Setting.php` | 设置界面移除 `frontend` 选项，使其无法被重新启用 |
| `Service/Migration.php` | 新增 `migrate_deprecate_frontend_acceleration()`，后台访问时摘除存量站点已保存的该项 |
| `Service/MirrorHealth.php` | `public.admincdn.com` 从健康探测目标移除（已无消费方） |

## 影响面

该选项**此前默认关闭**（`admincdn_files` 默认为 `['admin','emoji']`），因此**绝大多数站点此变更是空操作**。已启用的站点会在下次访问后台时自动摘除该项，其余加速项不受影响。

## 测试

`tests/test-deprecate-frontend-acceleration.php`，**14 项全过**。迁移是本次唯一写入站点数据的部分，所以覆盖得比较细：

```
== 形态一：索引数组 ['admin','frontend','emoji'] ==        2 项
== 形态二：关联数组 ['frontend'=>'frontend'] ==            3 项
== 形态三：关联数组里 frontend 值为空串 ==                 1 项
== 不该动的情况：没有 frontend ==                          2 项（含"不产生无谓写入"）
== 不该动的情况：缺失 / 序列化损坏 ==                      2 项（含"不放大已有损坏"）
== 其他加速项不受影响 ==                                   4 项
---- 14 passed, 0 failed ----
```

`tests/test-mirror-health-fallback.php` 同步为 38 项，新增断言 `public.admincdn.com` 已离开探测表。

## 背景

本次 admincdn 镜像端点排查中，`public.admincdn.com` 在源站返回 404。追查发现它有一个独立 vhost 指向空占位目录，遮住了本可工作的通配 vhost——但进一步分析发现，**即使"修好"这个 vhost 也是错的**，因为共享端点服务站点自有内容这件事本身不成立。
