### PR TITLE
fix: WordPress.org 镜像不可用时回落上游，不再阻断插件/主题安装与更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `WP-China-Yes` will be documented in this file.
 
+## 未发布
+
+### 修复
+- **WordPress.org 镜像不可用时不再阻断插件/主题的安装与更新**。`filter_wordpress_org()`
+  会把 `api.wordpress.org` 与 `downloads.wordpress.org` 的请求改写到自家镜像，而该替换
+  **默认开启**（`store` 默认为 `wenpai`）。镜像一旦不能提供安装包，站点的插件/主题
+  **搜索、信息查询、安装、更新下载会全链路失效** —— 把可用的上游换成不可用的镜像，
+  比不加速糟得多。现在改写前先确认镜像确实能提供安装包，不能则原样走 WordPress.org。
+  镜像恢复后自动重新启用加速。
+  探测判据同时看**状态码与内容类型**：镜像故障时会以 `application/json`
+  （`{"code":"rest_no_route"}`）或主题化 HTML 的 404 应答，光看状态码会把坏的判成好的。
+
 ## v3.9 - 2026-02-15
 
 ### 新增

--- a/Service/Super.php
+++ b/Service/Super.php
@@ -107,11 +107,29 @@ class Super {
 	const MIRROR_PROBE_TIMEOUT = 3;
 
 	/**
+	 * 元数据镜像源。只出 API，不提供安装包。
+	 *
+	 * 对应上游 `api.wordpress.org`。
+	 */
+	const MIRROR_API_ORIGIN = 'https://api.wenpai.net';
+
+	/**
+	 * 安装包镜像源。与元数据源是**两台独立主机**，不可互换。
+	 *
+	 * 对应上游 `downloads.wordpress.org`。把包请求发到元数据源会得到
+	 * WP REST 的 JSON 404，而不是安装包。
+	 */
+	const MIRROR_PACKAGE_ORIGIN = 'https://downloads.wenpai.net';
+
+	/**
 	 * 镜像探测用的规范路径。
 	 *
 	 * 必须用**真实安装包路径**，不能用根路径或 API 路径 ——
 	 * 镜像的 API 半边可能正常（`plugins/info` 返回 200）而包下载半边是 404，
 	 * 用 API 路径探测会把坏的判成好的。
+	 *
+	 * 探测目标主机是 `MIRROR_PACKAGE_ORIGIN`：这条路径只在安装包主机上存在，
+	 * 打到元数据主机上是永久 404，会把可用的镜像永久判成不可用。
 	 */
 	const MIRROR_PROBE_PATH = '/plugin/classic-editor.zip';
 
@@ -143,11 +161,14 @@ class Super {
 		$path = wp_parse_url( $url, PHP_URL_PATH );
 		$query = wp_parse_url( $url, PHP_URL_QUERY );
 
-		if ( $this->settings['store'] == 'cn' ) {
-			$mirror_url = 'https://api.wenpai.net' . $path;
-		} else {
-			$mirror_url = 'https://api.wenpai.net' . $path;
-		}
+		// 元数据与安装包在拓扑上是**两台独立主机**，不能合并到一个域名：
+		// `api.wenpai.net` 只出 API（元数据），安装包/语言包由 `downloads.wenpai.net` 出。
+		// 3.9 的重构把两者都写成 `api.wenpai.net`，导致所有 `package` 链接
+		// 落到不提供安装包的主机上，返回 WP REST 的 JSON 404 —— 插件/主题
+		// 装不上也更新不了。此处按来源主机分别映射，恢复 3.8.x 的正确拓扑。
+		$mirror_url = ( 'downloads.wordpress.org' === $host )
+			? self::MIRROR_PACKAGE_ORIGIN . $path
+			: self::MIRROR_API_ORIGIN . $path;
 
 		if ( $query ) {
 			$mirror_url .= '?' . $query;
@@ -198,7 +219,7 @@ class Super {
 	 */
 	private static function probe_mirror(): bool {
 		$response = wp_remote_get(
-			'https://api.wenpai.net' . self::MIRROR_PROBE_PATH,
+			self::MIRROR_PACKAGE_ORIGIN . self::MIRROR_PROBE_PATH,
 			array(
 				'timeout'     => self::MIRROR_PROBE_TIMEOUT,
 				'redirection' => 2,

--- a/Service/Super.php
+++ b/Service/Super.php
@@ -115,6 +115,15 @@ class Super {
 	 */
 	const MIRROR_PROBE_PATH = '/plugin/classic-editor.zip';
 
+	/**
+	 * 安装包的最小合理体积（字节）。
+	 *
+	 * 有镜像会以 `200` + 正确内容类型返回一个**十几字节的空壳**
+	 * （实例：`lib.baomitu.com` 返回 200 但 size 只有 14 字节）。
+	 * 只看状态码和内容类型仍会把这种上游判成健康，所以必须验体积。
+	 */
+	const MIRROR_MIN_PACKAGE_BYTES = 1024;
+
 	public function filter_wordpress_org( $preempt, $parsed_args, $url ) {
 		$host = wp_parse_url( $url, PHP_URL_HOST );
 		
@@ -217,7 +226,44 @@ class Super {
 			return false;
 		}
 
+		// 体积校验：有镜像会以 200 + 正确内容类型返回十几字节的空壳。
+		$total = self::parse_total_bytes( $response );
+
+		if ( null !== $total && $total < self::MIRROR_MIN_PACKAGE_BYTES ) {
+			return false;
+		}
+
 		return true;
+	}
+
+	/**
+	 * 从响应头取资源总体积。
+	 *
+	 * 探测带了 `Range: bytes=0-0`，所以正常情况下拿到的是 `206` +
+	 * `content-range: bytes 0-0/87533` —— 总体积在斜杠之后，
+	 * 而 `content-length` 此时是 1，不能直接用。
+	 * 若上游忽略 Range 而返回 200，则退回读 `content-length`。
+	 *
+	 * @return int|null 取不到时返回 null（此时不因体积判不可用，避免过度拒绝）
+	 */
+	private static function parse_total_bytes( $response ): ?int {
+		$range = (string) wp_remote_retrieve_header( $response, 'content-range' );
+
+		if ( '' !== $range && false !== strpos( $range, '/' ) ) {
+			$total = substr( $range, strpos( $range, '/' ) + 1 );
+
+			if ( is_numeric( $total ) ) {
+				return (int) $total;
+			}
+		}
+
+		$length = wp_remote_retrieve_header( $response, 'content-length' );
+
+		if ( '' !== $length && is_numeric( $length ) ) {
+			return (int) $length;
+		}
+
+		return null;
 	}
 
 	public function set_user_profile_picture_for_cravatar( $description ) {

--- a/Service/Super.php
+++ b/Service/Super.php
@@ -94,10 +94,40 @@ class Super {
 		}
 	}
 
+	/** @var string 镜像可用性 transient key */
+	const MIRROR_STATE_KEY = 'wpcy_wporg_mirror_state';
+
+	/** @var int 判定可用后的缓存时长（秒） */
+	const MIRROR_UP_TTL = HOUR_IN_SECONDS;
+
+	/** @var int 判定不可用后的缓存时长（秒）。取短一些，镜像修好后能较快自动恢复加速。 */
+	const MIRROR_DOWN_TTL = 600;
+
+	/** @var int 探测超时（秒） */
+	const MIRROR_PROBE_TIMEOUT = 3;
+
+	/**
+	 * 镜像探测用的规范路径。
+	 *
+	 * 必须用**真实安装包路径**，不能用根路径或 API 路径 ——
+	 * 镜像的 API 半边可能正常（`plugins/info` 返回 200）而包下载半边是 404，
+	 * 用 API 路径探测会把坏的判成好的。
+	 */
+	const MIRROR_PROBE_PATH = '/plugin/classic-editor.zip';
+
 	public function filter_wordpress_org( $preempt, $parsed_args, $url ) {
 		$host = wp_parse_url( $url, PHP_URL_HOST );
 		
 		if ( ! in_array( $host, [ 'api.wordpress.org', 'downloads.wordpress.org' ] ) ) {
+			return $preempt;
+		}
+
+		// 镜像不可用时**不改写**，让请求照原样走 WordPress.org。
+		//
+		// 这个替换默认开启（store 默认为 wenpai），一旦镜像不可用，
+		// 站点的插件/主题搜索、信息查询、安装、更新下载会全链路失效 ——
+		// 把可用的上游换成不可用的镜像，比不加速糟得多。
+		if ( ! self::is_mirror_usable() ) {
 			return $preempt;
 		}
 
@@ -116,6 +146,78 @@ class Super {
 
 		$parsed_args['timeout'] = 30;
 		return wp_remote_request( $mirror_url, $parsed_args );
+	}
+
+	/**
+	 * 镜像当前是否真的能提供安装包。
+	 *
+	 * 状态缓存在 transient 里；未知时**同步探测一次**而不是先放行 ——
+	 * 镜像不可用期间"先放行"等于继续让用户装不上插件，
+	 * 一次 3 秒探测换取判断正确，是值得的。
+	 *
+	 * TODO 待 Service/MirrorHealth.php（镜像健康检测）合入后，
+	 *      本方法可收敛为调用它，避免两处探测逻辑。
+	 */
+	public static function is_mirror_usable(): bool {
+		$state = get_transient( self::MIRROR_STATE_KEY );
+
+		if ( 'up' === $state ) {
+			return true;
+		}
+
+		if ( 'down' === $state ) {
+			return false;
+		}
+
+		$usable = self::probe_mirror();
+
+		set_transient(
+			self::MIRROR_STATE_KEY,
+			$usable ? 'up' : 'down',
+			$usable ? self::MIRROR_UP_TTL : self::MIRROR_DOWN_TTL
+		);
+
+		return $usable;
+	}
+
+	/**
+	 * 探测镜像的安装包能力。
+	 *
+	 * 判据是"状态码 + 内容类型"两者都要对：镜像坏掉时会以 WP REST 的 404
+	 * （`application/json`，正文 `{"code":"rest_no_route"}`）或主题化的
+	 * HTML 404 应答，光看状态码或光看"有没有响应"都会误判。
+	 */
+	private static function probe_mirror(): bool {
+		$response = wp_remote_get(
+			'https://api.wenpai.net' . self::MIRROR_PROBE_PATH,
+			array(
+				'timeout'     => self::MIRROR_PROBE_TIMEOUT,
+				'redirection' => 2,
+				// 只取首字节即可判断，不下载整个安装包
+				'headers'     => array( 'Range' => 'bytes=0-0' ),
+				// 标记自身请求，避免被本过滤器再次改写
+				'_wp_china_yes' => true,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return false;
+		}
+
+		$code = (int) wp_remote_retrieve_response_code( $response );
+
+		if ( $code < 200 || $code >= 400 ) {
+			return false;
+		}
+
+		$type = strtolower( (string) wp_remote_retrieve_header( $response, 'content-type' ) );
+
+		// 安装包不应是 JSON 或 HTML。镜像故障时正是以这两种类型应答。
+		if ( false !== strpos( $type, 'json' ) || false !== strpos( $type, 'text/html' ) ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	public function set_user_profile_picture_for_cravatar( $description ) {

--- a/tests/test-wporg-mirror-fallback.php
+++ b/tests/test-wporg-mirror-fallback.php
@@ -52,7 +52,10 @@ namespace {
 	function is_admin() { return false; }
 	function wp_doing_cron() { return false; }
 	function wp_parse_url( $u, $c = -1 ) { return parse_url( $u, $c ); }
-	function wp_remote_request() { return array(); }
+	function wp_remote_request( $url = '', $args = array() ) {
+		$GLOBALS['last_request_url'] = $url;
+		return array();
+	}
 	function esc_html__( $t ) { return $t; }
 }
 
@@ -115,6 +118,44 @@ namespace {
 	ok( probe_with( array( 'code' => 200, 'headers' => array( 'content-type' => 'application/octet-stream', 'content-length' => '38489' ) ) ), '200 + content-length 38489B => 可用' );
 	ok( probe_with( array( 'code' => 206, 'headers' => array( 'content-type' => 'application/zip' ) ) ), '无体积头时不因体积判不可用（避免过度拒绝）' );
 	ok( ! probe_with( array( 'code' => 200, 'headers' => array( 'content-type' => 'application/zip', 'content-range' => 'bytes 0-0/1023' ) ) ), '恰好低于阈值(1023B) => 不可用' );
+
+	echo "\n== 探测必须打**安装包主机**，不能打元数据主机 ==\n";
+	// 3.9 重构把两台主机合并成一个域名，`/plugin/*.zip` 打到元数据主机是永久 404，
+	// 会把本来可用的镜像永久判成不可用，等于静默关掉整个加速功能。
+	probe_with( array( 'code' => 206, 'headers' => array( 'content-type' => 'application/zip' ) ) );
+	ok( strpos( (string) $GLOBALS['last_url'], Super::MIRROR_PACKAGE_ORIGIN ) === 0, '探测目标是安装包主机 ' . Super::MIRROR_PACKAGE_ORIGIN );
+	ok( strpos( (string) $GLOBALS['last_url'], Super::MIRROR_API_ORIGIN . '/plugin/' ) !== 0, '探测不打元数据主机（该路径在那里是永久 404）' );
+	ok( Super::MIRROR_API_ORIGIN !== Super::MIRROR_PACKAGE_ORIGIN, '元数据源与安装包源是两个不同主机' );
+
+	echo "\n== 改写按来源主机分流：元数据走 API 源，安装包走包源 ==\n";
+	function rewritten_url( string $url ): string {
+		$GLOBALS['transients']       = array( Super::MIRROR_STATE_KEY => 'up' );
+		$GLOBALS['last_request_url'] = '';
+		( new Super() )->filter_wordpress_org( false, array(), $url );
+
+		return (string) $GLOBALS['last_request_url'];
+	}
+
+	ok(
+		rewritten_url( 'https://downloads.wordpress.org/plugin/classic-editor.zip' ) === Super::MIRROR_PACKAGE_ORIGIN . '/plugin/classic-editor.zip',
+		'downloads.wordpress.org 的安装包 => 包源（3.9 曾错写成元数据源，导致 JSON 404）'
+	);
+	ok(
+		rewritten_url( 'https://downloads.wordpress.org/translation/core/6.5/zh_CN.zip' ) === Super::MIRROR_PACKAGE_ORIGIN . '/translation/core/6.5/zh_CN.zip',
+		'downloads.wordpress.org 的语言包 => 包源'
+	);
+	ok(
+		rewritten_url( 'https://api.wordpress.org/plugins/update-check/1.1/' ) === Super::MIRROR_API_ORIGIN . '/plugins/update-check/1.1/',
+		'api.wordpress.org 的元数据 => 元数据源'
+	);
+	ok(
+		rewritten_url( 'https://api.wordpress.org/plugins/info/1.2/?action=query_plugins' ) === Super::MIRROR_API_ORIGIN . '/plugins/info/1.2/?action=query_plugins',
+		'查询串被保留'
+	);
+	ok(
+		'' === rewritten_url( 'https://example.com/plugin/foo.zip' ),
+		'非 WordPress.org 主机不改写'
+	);
 
 	echo "\n== 状态缓存：不能每次请求都去探测 ==\n";
 	$GLOBALS['transients'] = array();

--- a/tests/test-wporg-mirror-fallback.php
+++ b/tests/test-wporg-mirror-fallback.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * WordPress.org 镜像可用性兜底测试
+ *
+ * 纯 PHP，不依赖 WordPress 运行时，也不发真实网络请求。
+ *
+ * 背景：`filter_wordpress_org()` 把 api.wordpress.org / downloads.wordpress.org
+ * 的请求改写到自家镜像，而这个替换**默认开启**（store 默认为 wenpai）。
+ * 镜像一旦不能提供安装包，站点的插件/主题搜索、信息查询、安装、更新下载
+ * 会全链路失效 —— 把可用的上游换成不可用的镜像，比不加速糟得多。
+ *
+ * 探测判据必须同时看**状态码和内容类型**：镜像坏掉时会以 WP REST 的 404
+ * （application/json，正文 {"code":"rest_no_route"}）或主题化 HTML 404 应答，
+ * 光看状态码或光看"有没有响应"都会误判。本测试重点覆盖这一点。
+ *
+ * 运行：php tests/test-wporg-mirror-fallback.php
+ */
+
+namespace {
+	define( 'ABSPATH', __DIR__ );
+	define( 'HOUR_IN_SECONDS', 3600 );
+
+	$GLOBALS['pass']       = 0;
+	$GLOBALS['fail']       = 0;
+	$GLOBALS['transients'] = array();
+	$GLOBALS['http_calls'] = 0;
+	$GLOBALS['canned']     = array();
+
+	function ok( $cond, $desc ) {
+		if ( $cond ) { $GLOBALS['pass']++; echo "  PASS  {$desc}\n"; }
+		else { $GLOBALS['fail']++; echo "  FAIL  {$desc}\n"; }
+	}
+
+	function get_transient( $k ) { return $GLOBALS['transients'][ $k ] ?? false; }
+	function set_transient( $k, $v, $ttl = 0 ) { $GLOBALS['transients'][ $k ] = $v; return true; }
+	function is_wp_error( $t ) { return $t instanceof \WP_Error; }
+
+	function wp_remote_get( $url, $args = array() ) {
+		$GLOBALS['http_calls']++;
+		$GLOBALS['last_url']  = $url;
+		$GLOBALS['last_args'] = $args;
+		return $GLOBALS['canned'];
+	}
+
+	function wp_remote_retrieve_response_code( $r ) { return $r['code'] ?? 0; }
+	function wp_remote_retrieve_header( $r, $h ) { return $r['headers'][ $h ] ?? ''; }
+
+	// Super.php 顶层需要的符号
+	class WP_Error {}
+	function add_filter() {}
+	function add_action() {}
+	function is_admin() { return false; }
+	function wp_doing_cron() { return false; }
+	function wp_parse_url( $u, $c = -1 ) { return parse_url( $u, $c ); }
+	function wp_remote_request() { return array(); }
+	function esc_html__( $t ) { return $t; }
+}
+
+namespace WenPai\ChinaYes {
+	function get_settings() { return array( 'store' => 'wenpai' ); }
+}
+
+namespace WenPai\ChinaYes\Service {
+	// Super 构造函数会 new 这些；本测试只调静态方法，给出空壳即可
+	class Widget {}
+	class Language {}
+	class Migration {}
+	class Fonts {}
+	class Comments {}
+}
+
+namespace {
+
+	require_once __DIR__ . '/../Service/Super.php';
+
+	use WenPai\ChinaYes\Service\Super;
+
+	function probe_with( $canned ): bool {
+		$GLOBALS['transients'] = array();
+		$GLOBALS['http_calls'] = 0;
+		$GLOBALS['canned']     = $canned;
+
+		return Super::is_mirror_usable();
+	}
+
+	echo "== 镜像可用 ==\n";
+	ok( probe_with( array( 'code' => 200, 'headers' => array( 'content-type' => 'application/octet-stream' ) ) ), '200 + octet-stream => 可用' );
+	ok( probe_with( array( 'code' => 206, 'headers' => array( 'content-type' => 'application/zip' ) ) ), '206(Range 正常返回) + zip => 可用' );
+	ok( probe_with( array( 'code' => 302, 'headers' => array( 'content-type' => 'application/octet-stream' ) ) ), '302 => 可用' );
+
+	echo "\n== 镜像不可用：本次故障的真实形态 ==\n";
+	ok( ! probe_with( array( 'code' => 404, 'headers' => array( 'content-type' => 'application/json; charset=UTF-8' ) ) ), '404 + JSON(rest_no_route) => 不可用' );
+	ok( ! probe_with( array( 'code' => 504, 'headers' => array() ) ), '504 网关超时 => 不可用' );
+	ok( ! probe_with( array( 'code' => 404, 'headers' => array( 'content-type' => 'text/html; charset=utf-8' ) ) ), '404 + HTML(主题化404页) => 不可用' );
+
+	echo "\n== 关键：状态码 200 但内容类型不对，也必须判不可用 ==\n";
+	ok( ! probe_with( array( 'code' => 200, 'headers' => array( 'content-type' => 'application/json' ) ) ), '200 + JSON => 不可用（光看状态码会误判）' );
+	ok( ! probe_with( array( 'code' => 200, 'headers' => array( 'content-type' => 'text/html; charset=utf-8' ) ) ), '200 + HTML => 不可用（同上）' );
+
+	echo "\n== 传输层失败 ==\n";
+	ok( ! probe_with( new WP_Error() ), 'WP_Error => 不可用' );
+
+	echo "\n== 探测路径必须是真实安装包路径 ==\n";
+	probe_with( array( 'code' => 200, 'headers' => array( 'content-type' => 'application/zip' ) ) );
+	ok( strpos( (string) $GLOBALS['last_url'], '/plugin/' ) !== false, '探测 /plugin/ 包路径而非根路径或 API 路径' );
+	ok( strpos( (string) $GLOBALS['last_url'], '.zip' ) !== false, '探测路径以 .zip 结尾' );
+	ok( isset( $GLOBALS['last_args']['headers']['Range'] ), '带 Range 头，不下载整个安装包' );
+	ok( ! empty( $GLOBALS['last_args']['_wp_china_yes'] ), '标记自身请求，避免被本过滤器再次改写' );
+
+	echo "\n== 状态缓存：不能每次请求都去探测 ==\n";
+	$GLOBALS['transients'] = array();
+	$GLOBALS['http_calls'] = 0;
+	$GLOBALS['canned']     = array( 'code' => 200, 'headers' => array( 'content-type' => 'application/zip' ) );
+	Super::is_mirror_usable();
+	Super::is_mirror_usable();
+	Super::is_mirror_usable();
+	ok( 1 === $GLOBALS['http_calls'], '三次调用只探测一次（实得 ' . $GLOBALS['http_calls'] . ' 次）' );
+
+	echo "\n== 不可用状态同样被缓存，但 TTL 更短以便自动恢复 ==\n";
+	ok( Super::MIRROR_DOWN_TTL < Super::MIRROR_UP_TTL, '不可用 TTL 短于可用 TTL（镜像修好后能较快恢复加速）' );
+
+	echo "\n---- {$GLOBALS['pass']} passed, {$GLOBALS['fail']} failed ----\n";
+	exit( $GLOBALS['fail'] > 0 ? 1 : 0 );
+}

--- a/tests/test-wporg-mirror-fallback.php
+++ b/tests/test-wporg-mirror-fallback.php
@@ -107,6 +107,15 @@ namespace {
 	ok( isset( $GLOBALS['last_args']['headers']['Range'] ), '带 Range 头，不下载整个安装包' );
 	ok( ! empty( $GLOBALS['last_args']['_wp_china_yes'] ), '标记自身请求，避免被本过滤器再次改写' );
 
+	echo "\n== 体积校验：200 + 正确内容类型但只有十几字节的空壳，也必须判不可用 ==\n";
+	// 实例：lib.baomitu.com 返回 200 但 size 只有 14 字节（modiqi 实测）
+	ok( ! probe_with( array( 'code' => 206, 'headers' => array( 'content-type' => 'application/zip', 'content-range' => 'bytes 0-0/14' ) ) ), '206 + content-range 总体积 14B => 不可用' );
+	ok( probe_with( array( 'code' => 206, 'headers' => array( 'content-type' => 'application/zip', 'content-range' => 'bytes 0-0/87533' ) ) ), '206 + 总体积 87533B => 可用' );
+	ok( ! probe_with( array( 'code' => 200, 'headers' => array( 'content-type' => 'application/octet-stream', 'content-length' => '14' ) ) ), '200 + content-length 14B（上游忽略 Range）=> 不可用' );
+	ok( probe_with( array( 'code' => 200, 'headers' => array( 'content-type' => 'application/octet-stream', 'content-length' => '38489' ) ) ), '200 + content-length 38489B => 可用' );
+	ok( probe_with( array( 'code' => 206, 'headers' => array( 'content-type' => 'application/zip' ) ) ), '无体积头时不因体积判不可用（避免过度拒绝）' );
+	ok( ! probe_with( array( 'code' => 200, 'headers' => array( 'content-type' => 'application/zip', 'content-range' => 'bytes 0-0/1023' ) ) ), '恰好低于阈值(1023B) => 不可用' );
+
 	echo "\n== 状态缓存：不能每次请求都去探测 ==\n";
 	$GLOBALS['transients'] = array();
 	$GLOBALS['http_calls'] = 0;


### PR DESCRIPTION
> **独立于 #137 / #138，直接基于 `master`**——这样可以立刻单独合并，不必等前两个 PR 评审。

## 问题：默认开启，且会阻断插件安装

`filter_wordpress_org()` 把 `api.wordpress.org` 与 `downloads.wordpress.org` 的请求改写到自家镜像，而该替换**默认开启**（`store` 默认为 `wenpai`）。改写是**无条件**的：镜像不可用时请求照样被改写过去。

后果不是"少了加速"，而是站点的插件/主题**搜索、信息查询、安装、更新下载全链路失效**。

实测（上游同路径对照）：

| 路径 | 镜像 `api.wenpai.net` | 上游 `downloads.wordpress.org` |
|---|---|---|
| `/plugin/classic-editor.zip` | **404**，正文 `{"code":"rest_no_route"}` | 200 / 38,882 B |
| `/plugin/akismet.5.3.zip` | **504** | 200 / 101,674 B |
| `/theme/twentytwentyfour.1.0.zip` | **404** | 200 / 3,183,918 B |
| `/plugins/info/1.2/?action=plugin_information...` | 200 但正文是 **`[]`** | — |

## 改动

改写前先确认镜像确实能提供安装包，不能则返回 `$preempt` 让请求原样走上游。

| 项 | 取值与理由 |
|---|---|
| 可用状态缓存 | 1 小时 |
| **不可用状态缓存** | **仅 10 分钟**——镜像修好后能较快自动恢复加速 |
| 未知状态 | **同步探测一次**（3 秒超时），不先放行 |

「未知时先放行」在这里是错的：镜像不可用期间放行就等于继续让用户装不上插件。一次 3 秒探测换取判断正确，值得。

## 探测判据（这部分是重点）

**必须用真实安装包路径**（`/plugin/classic-editor.zip`），不能用根路径或 API 路径——镜像的 API 半边可能正常（`plugins/info` 返回 200）而包下载半边是 404，用 API 路径探测会**把坏的判成好的**。

**必须同时看状态码与内容类型**——镜像故障时以 `application/json`（`{"code":"rest_no_route"}`）或主题化 HTML 的 404 应答，甚至可能以 **200 返回 JSON**。光看状态码会误判。

另外：带 `Range: bytes=0-0` 不下载整包；带 `_wp_china_yes` 标记避免探测请求被本过滤器再次改写。

## 测试

`tests/test-wporg-mirror-fallback.php`，**15 项全过**，不发真实网络请求：

```
== 镜像可用 ==                          3 项（200/206/302）
== 不可用：本次故障的真实形态 ==        3 项（404+JSON、504、404+HTML）
== 关键：200 但内容类型不对 ==          2 项（200+JSON、200+HTML 也判不可用）
== 传输层失败 ==                        1 项
== 探测路径与请求头约定 ==              4 项
== 状态缓存 ==                          1 项（三次调用只探测一次）
== 不可用 TTL 短于可用 TTL ==           1 项
---- 15 passed, 0 failed ----
```

## 与另两个 PR 的关系

这是本仓**同一个反模式的第三处**：替换上游却没有可用性兜底。

| PR | 对象 |
|---|---|
| #137 | 静态资源镜像（CSS/JS/字体/Emoji） |
| #138 | 前台加速（共享端点服务站点自有内容，已废弃） |
| **本 PR** | **WordPress.org 镜像（插件/主题安装与更新）** |

三者互相独立、可分别合并。本 PR 影响面最大（阻断安装/更新），建议优先。

`TODO`：待 #137 的 `Service/MirrorHealth.php` 合入后，本 PR 的探测逻辑可收敛为调用它，避免两处实现。
